### PR TITLE
Remove explicit fake-xml-http-request in advance for the stripes-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-no-only-tests": "^2.3.1",
     "eslint-plugin-react-hooks": "^1.7.0",
-    "fake-xml-http-request": "2.0.0",
     "mocha": "^5.2.0",
     "query-string": "^5.0.0",
     "react": "^16.8.6",
@@ -59,9 +58,6 @@
     "prop-types": "^15.6.0",
     "react-highlighter": "^0.4.3",
     "react-intl": "^2.8.0"
-  },
-  "resolutions": {
-    "fake-xml-http-request": "2.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^2.7.0",


### PR DESCRIPTION
Having multiple versions of the fake-xml-http-request can prevent patching.