### PR TITLE
UIPFIMP-11: Support Static value submatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 # New features:
 * Create FindProfiles Plugin Component (UIPFIMP-1)
 * Add Re-Link Warning popup and Linked/Unlinked status into FindProfiles Plugin Component (UIPFIMP-2)
+* Job Profile Tree: Changes needed to support Static value submatches (UIPFIMP-11)

--- a/FindImportProfile/FindImportProfile.js
+++ b/FindImportProfile/FindImportProfile.js
@@ -40,6 +40,7 @@ const FindImportProfile = ({
   onClose,
   isSingleSelect,
   isMultiLink,
+  filterParams,
   ...rest
 }) => {
   const FindImportProfileContainer = profileContainers[entityKey];
@@ -140,7 +141,10 @@ const FindImportProfile = ({
     >
       {modalProps => (
         <>
-          <FindImportProfileContainer entityKey={entityKey}>
+          <FindImportProfileContainer
+            entityKey={entityKey}
+            filterParams={filterParams}
+          >
             {viewProps => (
               <PluginFindRecordModal
                 {...viewProps}
@@ -164,6 +168,7 @@ const FindImportProfile = ({
           <ConfirmationModal
             id="relink-profile"
             confirmLabel={<FormattedMessage id="ui-plugin-find-import-profile.confirmationModal.label" />}
+            bodyTag="div"
             heading={(
               <FormattedMessage
                 id="ui-plugin-find-import-profile.confirmationModal.heading"


### PR DESCRIPTION
## Purpose
It is needed to change the query string depending on the associated match profile position in the job profile tree.
## Approach

- Pass filterParams prop with a query value for the manifest to the containers

## Issue
[UIPFIMP-11](https://issues.folio.org/browse/UIPFIMP-11)