### PR TITLE
UIPFIMP-14: Upgrade Stripes to version 3.0.0, upgrade eslint :: DONE

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
     ],
     "import/no-extraneous-dependencies": 0,
     "import/prefer-default-export": 0,
+    "import/no-cycle": 0,
     "padding-line-between-statements": [
       "error",
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Change history for ui-plugin-find-import-profile
 
 ## **1.2.0** (in progress)
-* Update eslint to v6.2.1 (UIPFIMP-8)
-* Fix wording in relink modal (UIPFIMP-10)
+
+# Features added:
+* Job Profile Tree: Changes needed to support Static value submatches (UIPFIMP-11)
+* Upgrade Stripes and all the dependencies to version 3.0.0 (UIPFIMP-14)
+
+# Bugs fixed:
+* Wording in action profile relink modal is not correct (UIPFIMP-10)
 
 ## [1.1.2](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v1.1.2) (2020-01-03)
 

--- a/package.json
+++ b/package.json
@@ -25,45 +25,48 @@
     "test": "stripes test karma"
   },
   "devDependencies": {
-    "@bigtest/cli": "^0.2.2",
-    "@bigtest/interactor": "^0.9.2",
+    "@bigtest/interactor": "^0.9.1",
     "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.0.0",
-    "@folio/stripes": "^2.7.0",
-    "@folio/stripes-cli": "^1.13.0",
-    "@folio/stripes-core": "^3.3.0",
-    "babel-eslint": "^9.0.0",
+    "@folio/stripes": "^3.0.0",
+    "@folio/stripes-core": "^4.0.0",
+    "@folio/stripes-smart-components": "^3.0.0",
+    "@folio/stripes-acq-components": "^1.3.2",
+    "babel-eslint": "^10.0.3",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
     "eslint": "^6.2.1",
     "eslint-plugin-babel": "^5.3.0",
-    "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-no-only-tests": "^2.3.1",
+    "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^1.7.0",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
     "mocha": "^5.2.0",
     "query-string": "^5.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-redux": "^5.0.7",
-    "sinon": "^7.2.2",
-    "webpack": "^4.10.2"
+    "react-intl": "^2.9.0",
+    "react-router": "^4.3.1",
+    "react-router-dom": "^4.3.1",
+    "sinon": "^7.2.2"
   },
   "dependencies": {
-    "@folio/data-import": "^1.7.0",
-    "@folio/stripes-acq-components": "^1.1.0",
+    "@folio/data-import": "^1.7.3",
+    "@folio/stripes-acq-components": "^1.3.2",
     "classnames": "^2.2.5",
     "lodash": "^4.16.4",
     "prop-types": "^15.6.0",
+    "react-dropzone": "^7.0.1",
     "react-highlighter": "^0.4.3",
-    "react-intl": "^2.8.0"
+    "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.7.0",
-    "react-dom": "*",
-    "react-redux": "*",
+    "@folio/stripes": "^3.0.0",
     "react": "*",
-    "redux": "*"
+    "react-intl": "^2.9.0",
+    "react-router": "^4.3.1",
+    "react-router-dom": "^4.3.1"
   }
 }


### PR DESCRIPTION
## Purpose:
- Update `stripes` libraries and all the dependencies to `v3.0.0` (UIPFIMP-14);
- Update `eslint` and all the plugins and rules (UIDATIMP-376).