### PR TITLE
UIDATIMP-409: Provide default sort order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 # New features:
 * Create FindProfiles Plugin Component (UIPFIMP-1)
 * Add Re-Link Warning popup and Linked/Unlinked status into FindProfiles Plugin Component (UIPFIMP-2)
+* Provide default sort order (UIDATIMP-409)

--- a/FindImportProfile/FindImportProfileContainer/AbstractContainer.js
+++ b/FindImportProfile/FindImportProfileContainer/AbstractContainer.js
@@ -22,7 +22,7 @@ export class AbstractContainer extends Component {
 
   componentDidMount() {
     this.source = new StripesConnectedSource(this.props, this.logger);
-    this.props.mutator.query.replace('');
+    this.props.mutator.query.update({ sort: 'name' });
   }
 
   componentDidUpdate() {

--- a/test/bigtest/interactors/findImportProfileInteractor.js
+++ b/test/bigtest/interactors/findImportProfileInteractor.js
@@ -6,6 +6,7 @@ import {
   clickable,
   is,
   property,
+  text,
 } from '@bigtest/interactor';
 
 import ConfirmationModalInteractor from '@folio/stripes-components/lib/ConfirmationModal/tests/interactor';
@@ -21,6 +22,7 @@ class PluginModalInteractor {
   static defaultScope = '[data-test-find-records-modal]';
 
   instances = collection('[role=group] [role=row]', {
+    name: text('[role=gridcell] [class*="label--"]'),
     click: clickable(),
     selectLine: clickable('input[type="checkbox"]'),
   });

--- a/test/bigtest/tests/findImportProfiles.e2e.js
+++ b/test/bigtest/tests/findImportProfiles.e2e.js
@@ -221,7 +221,7 @@ describe('Find Import Profiles plugin', function () {
       });
 
       it('should return a set of results', function () {
-        return expect(findProfiles.modal.instances().length).to.be.equal(LESS_LINES_COUNT);
+        return expect(findProfiles.modal.instances().length).to.be.equal(5);
       });
 
       it('should display disabled save button', function () {

--- a/test/bigtest/tests/findImportProfilesSingleSelect.e2e.js
+++ b/test/bigtest/tests/findImportProfilesSingleSelect.e2e.js
@@ -49,6 +49,12 @@ describe('Find Data Import Profiles plugin with single select option', function 
       it('should return a set of results', function () {
         return expect(findProfiles.modal.instances().length).to.be.equal(MORE_LINES_COUNT);
       });
+
+      it('list should be sorted by the "name" column by default', () => {
+        expect(findProfiles.modal.instances(0).name).to.be.equal('Name 0');
+        expect(findProfiles.modal.instances(1).name).to.be.equal('Name 1');
+        expect(findProfiles.modal.instances(2).name).to.be.equal('Name 2');
+      });
     });
   });
 
@@ -86,6 +92,12 @@ describe('Find Data Import Profiles plugin with single select option', function 
 
       it('should return a set of results', function () {
         return expect(findProfiles.modal.instances().length).to.be.equal(LESS_LINES_COUNT);
+      });
+
+      it('list should be sorted by the "name" column by default', () => {
+        expect(findProfiles.modal.instances(0).name).to.be.equal('Approval plan records');
+        expect(findProfiles.modal.instances(1).name).to.be.equal('Create orders from acquisitions');
+        expect(findProfiles.modal.instances(2).name).to.be.equal('DDA discovery records');
       });
     });
   });
@@ -125,6 +137,12 @@ describe('Find Data Import Profiles plugin with single select option', function 
       it('should return a set of results', function () {
         return expect(findProfiles.modal.instances().length).to.be.equal(MORE_LINES_COUNT);
       });
+
+      it('list should be sorted by the "name" column by default', () => {
+        expect(findProfiles.modal.instances(0).name).to.be.equal('001 to Instance HRID');
+        expect(findProfiles.modal.instances(1).name).to.be.equal('EDI regular');
+        expect(findProfiles.modal.instances(2).name).to.be.equal('Invoice check');
+      });
     });
   });
 
@@ -161,7 +179,13 @@ describe('Find Data Import Profiles plugin with single select option', function 
       });
 
       it('should return a set of results', function () {
-        return expect(findProfiles.modal.instances().length).to.be.equal(LESS_LINES_COUNT);
+        return expect(findProfiles.modal.instances().length).to.be.equal(5);
+      });
+
+      it('list should be sorted by the "name" column by default', () => {
+        expect(findProfiles.modal.instances(0).name).to.be.equal('Name 0');
+        expect(findProfiles.modal.instances(1).name).to.be.equal('Name 1');
+        expect(findProfiles.modal.instances(2).name).to.be.equal('Name 2');
       });
     });
   });

--- a/test/bigtest/tests/relinkConfirmationModal.e2e.js
+++ b/test/bigtest/tests/relinkConfirmationModal.e2e.js
@@ -20,6 +20,7 @@ describe('Relink confirmation modal', () => {
 
       beforeEach(async function () {
         this.visit('/dummy');
+        this.server.get('/data-import-profiles/profileAssociations/:id/details', { childSnapshotWrappers: [{ contentType: 'MAPPING_PROFILE' }] });
         await findProfiles.whenLoaded();
         await findProfiles.actionProfileButton.click();
       });
@@ -68,6 +69,7 @@ describe('Relink confirmation modal', () => {
 
       beforeEach(async function () {
         this.visit('/dummy');
+        this.server.get('/data-import-profiles/profileAssociations/:id/details', { childSnapshotWrappers: [{ contentType: 'MAPPING_PROFILE' }] });
         await findProfiles.whenLoaded();
         await findProfiles.actionProfileButton.click();
       });
@@ -128,6 +130,7 @@ describe('Relink confirmation modal', () => {
 
       beforeEach(async function () {
         this.visit('/dummy');
+        this.server.get('/data-import-profiles/profileAssociations/:id/details', { childSnapshotWrappers: [{ contentType: 'MAPPING_PROFILE' }] });
         await findProfiles.whenLoaded();
         await findProfiles.jobProfileButton.click();
       });
@@ -148,6 +151,7 @@ describe('Relink confirmation modal', () => {
 
       beforeEach(async function () {
         this.visit('/dummy');
+        this.server.get('/data-import-profiles/profileAssociations/:id/details', { childSnapshotWrappers: [{ contentType: 'MAPPING_PROFILE' }] });
         await findProfiles.whenLoaded();
         await findProfiles.jobProfileButton.click();
       });
@@ -180,6 +184,7 @@ describe('Relink confirmation modal', () => {
 
       beforeEach(async function () {
         this.visit('/dummy');
+        this.server.get('/data-import-profiles/profileAssociations/:id/masters', { childSnapshotWrappers: [{ contentType: 'JOB_PROFILE' }] });
         await findProfiles.whenLoaded();
         await findProfiles.matchProfileButton.click();
       });
@@ -228,6 +233,7 @@ describe('Relink confirmation modal', () => {
 
       beforeEach(async function () {
         this.visit('/dummy');
+        this.server.get('/data-import-profiles/profileAssociations/:id/masters', { childSnapshotWrappers: [{ contentType: 'JOB_PROFILE' }] });
         await findProfiles.whenLoaded();
         await findProfiles.matchProfileButton.click();
       });
@@ -288,6 +294,7 @@ describe('Relink confirmation modal', () => {
 
       beforeEach(async function () {
         this.visit('/dummy');
+        this.server.get('/data-import-profiles/profileAssociations/:id/masters', { childSnapshotWrappers: [{ contentType: 'ACTION_PROFILE' }] });
         await findProfiles.whenLoaded();
         await findProfiles.mappingProfileButton.click();
       });
@@ -336,6 +343,7 @@ describe('Relink confirmation modal', () => {
 
       beforeEach(async function () {
         this.visit('/dummy');
+        this.server.get('/data-import-profiles/profileAssociations/:id/masters', { childSnapshotWrappers: [{ contentType: 'ACTION_PROFILE' }] });
         await findProfiles.whenLoaded();
         await findProfiles.mappingProfileButton.click();
       });


### PR DESCRIPTION
## Descriptions
When an associator profile component is selected, the default sort should be alpha A-Z by profile name
## Approach

- Add sort by name to query
- Fix tests

## Issue
[UIDATIMP-409](https://issues.folio.org/browse/UIDATIMP-409)
## Tests
![tests](https://user-images.githubusercontent.com/55138456/76611237-d9777700-6522-11ea-96de-8b9d6805ce8b.png)
