### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-plugin-find-import-profile
 
-## **1.2.0** (in progress)
+## [1.2.0](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v1.2.0) (2020-03-13)
 
 # Features added:
 * Job Profile Tree: Changes needed to support Static value submatches (UIPFIMP-11)

--- a/FindImportProfile/FindImportProfile.js
+++ b/FindImportProfile/FindImportProfile.js
@@ -195,6 +195,7 @@ FindImportProfile.propTypes = {
   entityKey: PropTypes.string.isRequired,
   parentType: PropTypes.string.isRequired,
   masterType: PropTypes.string.isRequired,
+  filterParams: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   profileName: PropTypes.string,
   isMultiLink: PropTypes.bool,
   disabled: PropTypes.bool,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-find-import-profile",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Find and select Data Import Profiles plugin for Stripes",
   "repository": "folio-org/ui-plugin-find-import-profile",
   "publishConfig": {
@@ -17,7 +17,7 @@
     "okapiInterfaces": {
       "data-import": "3.0",
       "source-manager-job-executions": "1.0",
-      "data-import-converter-storage": "1.0"
+      "data-import-converter-storage": "1.2"
     }
   },
   "scripts": {
@@ -53,7 +53,7 @@
     "sinon": "^7.2.2"
   },
   "dependencies": {
-    "@folio/data-import": "^1.7.3",
+    "@folio/data-import": "^1.8.0",
     "@folio/stripes-acq-components": "^1.3.2",
     "classnames": "^2.2.5",
     "lodash": "^4.16.4",


### PR DESCRIPTION
## [1.2.0](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v1.2.0) (2020-03-13)

# Features added:
* Job Profile Tree: Changes needed to support Static value submatches (UIPFIMP-11)
* Upgrade Stripes and all the dependencies to version 3.0.0 (UIPFIMP-14)

# Bugs fixed:
* Wording in action profile relink modal is not correct (UIPFIMP-10)