### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-plugin-find-import-profile
 
+## [1.2.1](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v1.2.1) (2020-03-19)
+
+# Bugs fixed:
+* Update @folio/stripes-acq-components dependency version
+
 ## [1.2.0](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v1.2.0) (2020-03-13)
 
 # Features added:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-find-import-profile",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Find and select Data Import Profiles plugin for Stripes",
   "repository": "folio-org/ui-plugin-find-import-profile",
   "publishConfig": {
@@ -33,7 +33,7 @@
     "@folio/stripes": "^3.0.0",
     "@folio/stripes-core": "^4.0.0",
     "@folio/stripes-smart-components": "^3.0.0",
-    "@folio/stripes-acq-components": "^1.3.2",
+    "@folio/stripes-acq-components": "^2.0.1",
     "babel-eslint": "^10.0.3",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",


### PR DESCRIPTION
## [1.2.1](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v1.2.1) (2020-03-19)

### Bugs fixed:
- Update @folio/stripes-acq-components dependency version