### PR TITLE
UIPFIMP-22: Add missed `resources` prop to `listTemplate` in `AbstractContainer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features added:
 * Handle import of stripes-acq-components to modules and platform (UISACQCOMP-3)
 * Update dependencies versions
+* Add `resources` prop to `listTemplate` in `AbstractContainer` (UIPFIMP-22)
 
 ## [2.0.1](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v2.0.1) (2020-06-18)
 

--- a/FindImportProfile/FindImportProfileContainer/AbstractContainer.js
+++ b/FindImportProfile/FindImportProfileContainer/AbstractContainer.js
@@ -66,6 +66,7 @@ export class AbstractContainer extends Component {
       searchTerm: '',
       selectRecord: null,
       selectedRecords: [],
+      resources,
     });
 
     if (this.source) {


### PR DESCRIPTION
## Ticket
[UIPFIMP-22](https://issues.folio.org/browse/UIPFIMP-22)