### PR TITLE
UIPFIMP-44: Cover <FindImportProfileContainer> with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## **5.0.1** (in progress)
 
 ### Features added:
-* Cover <FindImportProfile> component with tests (UIPFIMP-42)
+* Cover `<FindImportProfile>` component with tests (UIPFIMP-42)
+* Cover `<FindImportProfileContainer>` container with tests (UIPFIMP-44)
 
 ## [5.0.0](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v5.0.0) (2021-10-08)
 

--- a/FindImportProfile/FindImportProfileContainer/tests/ActionProfilesContainer.test.js
+++ b/FindImportProfile/FindImportProfileContainer/tests/ActionProfilesContainer.test.js
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import {
+  noop,
+  get,
+} from 'lodash';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+
+import '../../../test/jest/__mock__';
+import {
+  buildMutator,
+  buildResources,
+} from '@folio/stripes-data-transfer-components/test/helpers';
+import { buildStripes } from '@folio/data-import/test/jest/helpers';
+import { actionProfilesShape } from '@folio/data-import/src/settings/ActionProfiles';
+import { translationsProperties } from '../../../test/jest/helpers';
+
+import ActionProfilesContainer from '../ActionProfilesContainer';
+
+const mockUpdate = jest.fn();
+const mockReplace = jest.fn();
+
+const stripesProp = buildStripes();
+const resourcesProp = buildResources({ resourceName: 'actionProfiles' });
+const mutatorProp = buildMutator({
+  query: {
+    update: mockUpdate,
+    replace: mockReplace,
+  },
+});
+const mockedChildren = jest.fn(() => (
+  <div>
+    <span>Children</span>
+  </div>
+));
+
+const renderActionProfilesContainer = () => {
+  const component = (
+    <ActionProfilesContainer
+      stripes={stripesProp}
+      resources={resourcesProp}
+      mutator={mutatorProp}
+      entityKey="actionProfiles"
+      profileShape={actionProfilesShape}
+    >
+      {mockedChildren}
+    </ActionProfilesContainer>
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('<ActionProfilesContainer>', () => {
+  afterEach(() => {
+    mockedChildren.mockClear();
+    mockUpdate.mockClear();
+    mockReplace.mockClear();
+  });
+
+  it('renders children', () => {
+    const { getByText } = renderActionProfilesContainer();
+
+    expect(getByText('Children')).toBeInTheDocument();
+  });
+
+  it('calls children render prop with correct arguments', () => {
+    renderActionProfilesContainer();
+
+    const idPrefix = 'uiPluginFindImportProfile-';
+    const expectedData = { records: get(resourcesProp, ['records', 'records'], []) };
+
+    expect(mockedChildren.mock.calls[0][0].columnWidths).toEqual(actionProfilesShape.columnWidths);
+    expect(mockedChildren.mock.calls[0][0].visibleColumns).toEqual(actionProfilesShape.visibleColumns);
+    expect(mockedChildren.mock.calls[0][0].sortableColumns).toEqual(actionProfilesShape.visibleColumns);
+    expect(mockedChildren.mock.calls[0][0].data).toEqual(expectedData);
+    expect(mockedChildren.mock.calls[0][0].stripes).toEqual(stripesProp);
+    expect(mockedChildren.mock.calls[0][0].renderFilters).toEqual(noop);
+    expect(mockedChildren.mock.calls[0][0].idPrefix).toEqual(idPrefix);
+    expect(mockedChildren.mock.calls[0][0].queryGetter()).toEqual({});
+  });
+
+  it('allows to set query', () => {
+    renderActionProfilesContainer();
+
+    const nsValues1 = {
+      'users.query': 'test1',
+      'users.filters': 'active',
+      userId: 1,
+    };
+    const nsValues2 = {
+      'users.query': 'test2',
+      'users.filters': 'active',
+      userId: 2,
+    };
+    const state1 = { changeType: 'reset' };
+    const state2 = { changeType: 'update' };
+
+    mockedChildren.mock.calls[0][0].querySetter({
+      nsValues: nsValues1,
+      state: state1,
+    });
+    mockedChildren.mock.calls[0][0].querySetter({
+      nsValues: nsValues2,
+      state: state2,
+    });
+
+    expect(mockReplace.mock.calls[0][0]).toEqual(nsValues1);
+    expect(mockUpdate.mock.calls[1][0]).toEqual(nsValues2);
+  });
+});

--- a/FindImportProfile/FindImportProfileContainer/tests/JobProfilesContainer.test.js
+++ b/FindImportProfile/FindImportProfileContainer/tests/JobProfilesContainer.test.js
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import {
+  noop,
+  get,
+} from 'lodash';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+
+import '../../../test/jest/__mock__';
+import {
+  buildMutator,
+  buildResources,
+} from '@folio/stripes-data-transfer-components/test/helpers';
+import { buildStripes } from '@folio/data-import/test/jest/helpers';
+import { jobProfilesShape } from '@folio/data-import/src/settings/JobProfiles';
+import { translationsProperties } from '../../../test/jest/helpers';
+
+import JobProfilesContainer from '../JobProfilesContainer';
+
+const stripesProp = buildStripes();
+const resourcesProp = buildResources({ resourceName: 'jobProfiles' });
+const mutatorProp = buildMutator({ query: { update: noop } });
+const mockedChildren = jest.fn(() => (
+  <div>
+    <span>Children</span>
+  </div>
+));
+
+const renderJobProfilesContainer = () => {
+  const component = (
+    <JobProfilesContainer
+      stripes={stripesProp}
+      resources={resourcesProp}
+      mutator={mutatorProp}
+      entityKey="jobProfiles"
+      profileShape={jobProfilesShape}
+    >
+      {mockedChildren}
+    </JobProfilesContainer>
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('<JobProfilesContainer>', () => {
+  afterEach(() => {
+    mockedChildren.mockClear();
+  });
+
+  it('renders children', () => {
+    const { getByText } = renderJobProfilesContainer();
+
+    expect(getByText('Children')).toBeInTheDocument();
+  });
+
+  it('calls children render prop with appropriate arguments', () => {
+    renderJobProfilesContainer();
+
+    const idPrefix = 'uiPluginFindImportProfile-';
+    const expectedData = { records: get(resourcesProp, ['records', 'records'], []) };
+
+    expect(mockedChildren.mock.calls[0][0].columnWidths).toEqual(jobProfilesShape.columnWidths);
+    expect(mockedChildren.mock.calls[0][0].visibleColumns).toEqual(jobProfilesShape.visibleColumns);
+    expect(mockedChildren.mock.calls[0][0].sortableColumns).toEqual(jobProfilesShape.visibleColumns);
+    expect(mockedChildren.mock.calls[0][0].stripes).toEqual(stripesProp);
+    expect(mockedChildren.mock.calls[0][0].data).toEqual(expectedData);
+    expect(mockedChildren.mock.calls[0][0].renderFilters).toEqual(noop);
+    expect(mockedChildren.mock.calls[0][0].idPrefix).toEqual(idPrefix);
+  });
+});

--- a/FindImportProfile/FindImportProfileContainer/tests/MappingProfilesContainer.test.js
+++ b/FindImportProfile/FindImportProfileContainer/tests/MappingProfilesContainer.test.js
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import {
+  noop,
+  get,
+} from 'lodash';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+
+import '../../../test/jest/__mock__';
+import {
+  buildMutator,
+  buildResources,
+} from '@folio/stripes-data-transfer-components/test/helpers';
+import { buildStripes } from '@folio/data-import/test/jest/helpers';
+import { mappingProfilesShape } from '@folio/data-import/src/settings/MappingProfiles';
+import { translationsProperties } from '../../../test/jest/helpers';
+
+import MappingProfilesContainer from '../MappingProfilesContainer';
+
+const stripesProp = buildStripes();
+const resourcesProp = buildResources({ resourceName: 'mappingProfiles' });
+const mutatorProp = buildMutator({ query: { update: noop } });
+const mockedChildren = jest.fn(() => (
+  <div>
+    <span>Children</span>
+  </div>
+));
+
+const renderMappingProfilesContainer = () => {
+  const component = (
+    <MappingProfilesContainer
+      stripes={stripesProp}
+      resources={resourcesProp}
+      mutator={mutatorProp}
+      entityKey="mappingProfiles"
+      profileShape={mappingProfilesShape}
+    >
+      {mockedChildren}
+    </MappingProfilesContainer>
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('<MappingProfilesContainer>', () => {
+  afterEach(() => {
+    mockedChildren.mockClear();
+  });
+
+  it('renders children', () => {
+    const { getByText } = renderMappingProfilesContainer();
+
+    expect(getByText('Children')).toBeInTheDocument();
+  });
+
+  it('calls children render prop with appropriate arguments', () => {
+    renderMappingProfilesContainer();
+
+    const idPrefix = 'uiPluginFindImportProfile-';
+    const expectedData = { records: get(resourcesProp, ['records', 'records'], []) };
+
+    expect(mockedChildren.mock.calls[0][0].columnWidths).toEqual(mappingProfilesShape.columnWidths);
+    expect(mockedChildren.mock.calls[0][0].visibleColumns).toEqual(mappingProfilesShape.visibleColumns);
+    expect(mockedChildren.mock.calls[0][0].sortableColumns).toEqual(mappingProfilesShape.visibleColumns);
+    expect(mockedChildren.mock.calls[0][0].data).toEqual(expectedData);
+    expect(mockedChildren.mock.calls[0][0].renderFilters).toEqual(noop);
+    expect(mockedChildren.mock.calls[0][0].stripes).toEqual(stripesProp);
+    expect(mockedChildren.mock.calls[0][0].idPrefix).toEqual(idPrefix);
+  });
+});

--- a/FindImportProfile/FindImportProfileContainer/tests/MatchProfilesContainer.test.js
+++ b/FindImportProfile/FindImportProfileContainer/tests/MatchProfilesContainer.test.js
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import {
+  noop,
+  get,
+} from 'lodash';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+
+import '../../../test/jest/__mock__';
+import {
+  buildMutator,
+  buildResources,
+} from '@folio/stripes-data-transfer-components/test/helpers';
+import { buildStripes } from '@folio/data-import/test/jest/helpers';
+import { matchProfilesShape } from '@folio/data-import/src/settings/MatchProfiles';
+import { translationsProperties } from '../../../test/jest/helpers';
+
+import MatchProfilesContainer from '../MatchProfilesContainer';
+
+const stripesProp = buildStripes();
+const resourcesProp = buildResources({ resourceName: 'matchProfiles' });
+const mutatorProp = buildMutator({ query: { update: noop } });
+const mockedChildren = jest.fn(() => (
+  <div>
+    <span>Children</span>
+  </div>
+));
+
+const renderMatchProfilesContainer = () => {
+  const component = (
+    <MatchProfilesContainer
+      stripes={stripesProp}
+      resources={resourcesProp}
+      mutator={mutatorProp}
+      entityKey="matchProfiles"
+      profileShape={matchProfilesShape}
+    >
+      {mockedChildren}
+    </MatchProfilesContainer>
+  );
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('<MatchProfilesContainer>', () => {
+  afterEach(() => {
+    mockedChildren.mockClear();
+  });
+
+  it('renders children', () => {
+    const { getByText } = renderMatchProfilesContainer();
+
+    expect(getByText('Children')).toBeInTheDocument();
+  });
+
+  it('calls children render prop with appropriate arguments', () => {
+    renderMatchProfilesContainer();
+
+    const idPrefix = 'uiPluginFindImportProfile-';
+    const expectedData = { records: get(resourcesProp, ['records', 'records'], []) };
+
+    expect(mockedChildren.mock.calls[0][0].columnWidths).toEqual(matchProfilesShape.columnWidths);
+    expect(mockedChildren.mock.calls[0][0].visibleColumns).toEqual(matchProfilesShape.visibleColumns);
+    expect(mockedChildren.mock.calls[0][0].sortableColumns).toEqual(matchProfilesShape.visibleColumns);
+    expect(mockedChildren.mock.calls[0][0].renderFilters).toEqual(noop);
+    expect(mockedChildren.mock.calls[0][0].stripes).toEqual(stripesProp);
+    expect(mockedChildren.mock.calls[0][0].data).toEqual(expectedData);
+    expect(mockedChildren.mock.calls[0][0].idPrefix).toEqual(idPrefix);
+  });
+});


### PR DESCRIPTION
# Purpose
* Cover `<FindImportProfileContainer>` container with tests using RTL + Jest

# Approach
* Cover `<FindImportProfileContainer>` container with tests using RTL + Jest

# Refs
* https://issues.folio.org/browse/UIPFIMP-44

# Screenshots
![Screenshot (127)](https://user-images.githubusercontent.com/89512426/144579062-ed321368-0e21-413e-a68b-7bc702570075.png)
