### PR TITLE
UIPFIMP-57: Add accessibility testing to automated tests in UIPFIMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-plugin-find-import-profile
 
+## **6.1.0** (in progress)
+
+### Features added:
+* Add accessibiity testing to automated tests in UIPFIMP (UIPFIMP-57)
+
 ## [6.0.1](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v6.0.1) (2023-02-24)
 
 ### Bugs fixed:

--- a/FindImportProfile/FindImportProfile.test.js
+++ b/FindImportProfile/FindImportProfile.test.js
@@ -3,10 +3,7 @@
 import React from 'react';
 import { act } from '@testing-library/react';
 import { noop } from 'lodash';
-import {
-  axe,
-  toHaveNoViolations,
-} from 'jest-axe';
+import { axe } from 'jest-axe';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -19,8 +16,6 @@ import FindImportProfile from './FindImportProfile';
 import { fetchAssociations } from './utils/fetchAssociations';
 import { PluginFindRecordModal } from '@folio/stripes-acq-components';
 import { ConfirmationModal } from '@folio/stripes/components';
-
-expect.extend(toHaveNoViolations);
 
 const mockModalProps = {
   closeModal: () => {},

--- a/FindImportProfile/FindImportProfile.test.js
+++ b/FindImportProfile/FindImportProfile.test.js
@@ -3,6 +3,10 @@
 import React from 'react';
 import { act } from '@testing-library/react';
 import { noop } from 'lodash';
+import {
+  axe,
+  toHaveNoViolations,
+} from 'jest-axe';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -15,6 +19,8 @@ import FindImportProfile from './FindImportProfile';
 import { fetchAssociations } from './utils/fetchAssociations';
 import { PluginFindRecordModal } from '@folio/stripes-acq-components';
 import { ConfirmationModal } from '@folio/stripes/components';
+
+expect.extend(toHaveNoViolations);
 
 const mockModalProps = {
   closeModal: () => {},
@@ -119,6 +125,13 @@ const renderFindImportProfile = ({
 };
 
 describe('FindImportProfile', () => {
+  it('should be rendered with no axe errors', async () => {
+    const { container } = renderFindImportProfile(findImportProfileProps);
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+
   it('should be rendered', () => {
     const { getByText } = renderFindImportProfile(findImportProfileProps);
 

--- a/FindImportProfile/FindImportProfileContainer/tests/ActionProfilesContainer.test.js
+++ b/FindImportProfile/FindImportProfileContainer/tests/ActionProfilesContainer.test.js
@@ -3,10 +3,7 @@ import {
   noop,
   get,
 } from 'lodash';
-import {
-  axe,
-  toHaveNoViolations,
-} from 'jest-axe';
+import { axe } from 'jest-axe';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -20,8 +17,6 @@ import { actionProfilesShape } from '@folio/data-import/src/settings/ActionProfi
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import ActionProfilesContainer from '../ActionProfilesContainer';
-
-expect.extend(toHaveNoViolations);
 
 const mockUpdate = jest.fn();
 const mockReplace = jest.fn();

--- a/FindImportProfile/FindImportProfileContainer/tests/ActionProfilesContainer.test.js
+++ b/FindImportProfile/FindImportProfileContainer/tests/ActionProfilesContainer.test.js
@@ -3,6 +3,10 @@ import {
   noop,
   get,
 } from 'lodash';
+import {
+  axe,
+  toHaveNoViolations,
+} from 'jest-axe';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -16,6 +20,8 @@ import { actionProfilesShape } from '@folio/data-import/src/settings/ActionProfi
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import ActionProfilesContainer from '../ActionProfilesContainer';
+
+expect.extend(toHaveNoViolations);
 
 const mockUpdate = jest.fn();
 const mockReplace = jest.fn();
@@ -55,6 +61,13 @@ describe('<ActionProfilesContainer>', () => {
     mockedChildren.mockClear();
     mockUpdate.mockClear();
     mockReplace.mockClear();
+  });
+
+  it('should be rendered with no axe errors', async () => {
+    const { container } = renderActionProfilesContainer();
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
   });
 
   it('renders children', () => {

--- a/FindImportProfile/FindImportProfileContainer/tests/JobProfilesContainer.test.js
+++ b/FindImportProfile/FindImportProfileContainer/tests/JobProfilesContainer.test.js
@@ -3,6 +3,10 @@ import {
   noop,
   get,
 } from 'lodash';
+import {
+  axe,
+  toHaveNoViolations,
+} from 'jest-axe';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -16,6 +20,8 @@ import { jobProfilesShape } from '@folio/data-import/src/settings/JobProfiles';
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import JobProfilesContainer from '../JobProfilesContainer';
+
+expect.extend(toHaveNoViolations);
 
 const stripesProp = buildStripes();
 const resourcesProp = buildResources({ resourceName: 'jobProfiles' });
@@ -45,6 +51,13 @@ const renderJobProfilesContainer = () => {
 describe('<JobProfilesContainer>', () => {
   afterEach(() => {
     mockedChildren.mockClear();
+  });
+
+  it('should be rendered with no axe errors', async () => {
+    const { container } = renderJobProfilesContainer();
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
   });
 
   it('renders children', () => {

--- a/FindImportProfile/FindImportProfileContainer/tests/JobProfilesContainer.test.js
+++ b/FindImportProfile/FindImportProfileContainer/tests/JobProfilesContainer.test.js
@@ -3,10 +3,7 @@ import {
   noop,
   get,
 } from 'lodash';
-import {
-  axe,
-  toHaveNoViolations,
-} from 'jest-axe';
+import { axe } from 'jest-axe';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -20,8 +17,6 @@ import { jobProfilesShape } from '@folio/data-import/src/settings/JobProfiles';
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import JobProfilesContainer from '../JobProfilesContainer';
-
-expect.extend(toHaveNoViolations);
 
 const stripesProp = buildStripes();
 const resourcesProp = buildResources({ resourceName: 'jobProfiles' });

--- a/FindImportProfile/FindImportProfileContainer/tests/MappingProfilesContainer.test.js
+++ b/FindImportProfile/FindImportProfileContainer/tests/MappingProfilesContainer.test.js
@@ -3,10 +3,7 @@ import {
   noop,
   get,
 } from 'lodash';
-import {
-  axe,
-  toHaveNoViolations,
-} from 'jest-axe';
+import { axe } from 'jest-axe';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -20,8 +17,6 @@ import { mappingProfilesShape } from '@folio/data-import/src/settings/MappingPro
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import MappingProfilesContainer from '../MappingProfilesContainer';
-
-expect.extend(toHaveNoViolations);
 
 const stripesProp = buildStripes();
 const resourcesProp = buildResources({ resourceName: 'mappingProfiles' });

--- a/FindImportProfile/FindImportProfileContainer/tests/MappingProfilesContainer.test.js
+++ b/FindImportProfile/FindImportProfileContainer/tests/MappingProfilesContainer.test.js
@@ -3,6 +3,10 @@ import {
   noop,
   get,
 } from 'lodash';
+import {
+  axe,
+  toHaveNoViolations,
+} from 'jest-axe';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -16,6 +20,8 @@ import { mappingProfilesShape } from '@folio/data-import/src/settings/MappingPro
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import MappingProfilesContainer from '../MappingProfilesContainer';
+
+expect.extend(toHaveNoViolations);
 
 const stripesProp = buildStripes();
 const resourcesProp = buildResources({ resourceName: 'mappingProfiles' });
@@ -45,6 +51,13 @@ const renderMappingProfilesContainer = () => {
 describe('<MappingProfilesContainer>', () => {
   afterEach(() => {
     mockedChildren.mockClear();
+  });
+
+  it('should be rendered with no axe errors', async () => {
+    const { container } = renderMappingProfilesContainer();
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
   });
 
   it('renders children', () => {

--- a/FindImportProfile/FindImportProfileContainer/tests/MatchProfilesContainer.test.js
+++ b/FindImportProfile/FindImportProfileContainer/tests/MatchProfilesContainer.test.js
@@ -3,6 +3,10 @@ import {
   noop,
   get,
 } from 'lodash';
+import {
+  axe,
+  toHaveNoViolations,
+} from 'jest-axe';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -16,6 +20,8 @@ import { matchProfilesShape } from '@folio/data-import/src/settings/MatchProfile
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import MatchProfilesContainer from '../MatchProfilesContainer';
+
+expect.extend(toHaveNoViolations);
 
 const stripesProp = buildStripes();
 const resourcesProp = buildResources({ resourceName: 'matchProfiles' });
@@ -45,6 +51,13 @@ const renderMatchProfilesContainer = () => {
 describe('<MatchProfilesContainer>', () => {
   afterEach(() => {
     mockedChildren.mockClear();
+  });
+
+  it('should be rendered with no axe errors', async () => {
+    const { container } = renderMatchProfilesContainer();
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
   });
 
   it('renders children', () => {

--- a/FindImportProfile/FindImportProfileContainer/tests/MatchProfilesContainer.test.js
+++ b/FindImportProfile/FindImportProfileContainer/tests/MatchProfilesContainer.test.js
@@ -3,10 +3,7 @@ import {
   noop,
   get,
 } from 'lodash';
-import {
-  axe,
-  toHaveNoViolations,
-} from 'jest-axe';
+import { axe } from 'jest-axe';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
@@ -20,8 +17,6 @@ import { matchProfilesShape } from '@folio/data-import/src/settings/MatchProfile
 import { translationsProperties } from '../../../test/jest/helpers';
 
 import MatchProfilesContainer from '../MatchProfilesContainer';
-
-expect.extend(toHaveNoViolations);
 
 const stripesProp = buildStripes();
 const resourcesProp = buildResources({ resourceName: 'matchProfiles' });

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "identity-obj-proxy": "^3.0.0",
     "inflected": "^2.0.4",
     "jest": "^26.1.0",
+    "jest-axe": "^7.0.0",
     "jest-junit": "^13.0.0",
     "miragejs": "^0.1.40",
     "mocha": "^9.0.0",

--- a/test/jest/jest.setup.js
+++ b/test/jest/jest.setup.js
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom/extend-expect';
+import 'jest-axe/extend-expect';


### PR DESCRIPTION
## Purpose

* Use `axe-core` and `jest-axe` to add accessibility tests to components within unit tests.

## Approach

* Installed `jest-axe` to `devDependencies` in `package.json`
* Added accessibility tests to all the components, using [this instruction](https://folio-org.github.io/stripes-components/?path=/story/guides-accessibility-automated-accessibility-testing--page)

## Refs

[UIPFIMP-57](https://issues.folio.org/browse/UIPFIMP-57)
