### PR TITLE
UIPFIMP-58: Return profile associations when linking the profile instead of the record itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features added:
 * Add accessibiity testing to automated tests in UIPFIMP (UIPFIMP-57)
+* Return profile associations when linking the profile instead of the record itself (UIPFIMP-58)
 
 ## [6.0.1](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v6.0.1) (2023-02-24)
 

--- a/FindImportProfile/FindImportProfile.js
+++ b/FindImportProfile/FindImportProfile.js
@@ -152,10 +152,11 @@ const FindImportProfile = ({
     const requests = records.map(record => fetchAssociations(okapi, record.id, masterType, parentType, entityKey));
 
     try {
-      const associations = await Promise.all(requests);
+      const attachedProfilesWithAssociations = await Promise.all(requests);
+      const associations = attachedProfilesWithAssociations.map(item => item.childSnapshotWrappers || []);
 
       if (profileType === ENTITY_KEYS.JOB_PROFILES && entityKey === ENTITY_KEYS.ACTION_PROFILES) {
-        handleAttachingToJobProfile(associations, records, onSaveMultiple);
+        handleAttachingToJobProfile(associations, attachedProfilesWithAssociations, onSaveMultiple);
       } else {
         const filteredAssociations = filterAssociations(flattenDeep(associations));
         const confirmationModalMessage = getMessage(filteredAssociations, isSingleSelected);
@@ -170,7 +171,7 @@ const FindImportProfile = ({
         setConfirmationHeading(confirmHeading);
         setConfirmationLabel(confirmLabel);
 
-        handleProfilesSelect(filteredAssociations, confirmationModalMessage, records, onSaveMultiple);
+        handleProfilesSelect(filteredAssociations, confirmationModalMessage, attachedProfilesWithAssociations, onSaveMultiple);
       }
     } catch (error) {
       console.error(error); // eslint-disable-line no-console

--- a/FindImportProfile/FindImportProfile.js
+++ b/FindImportProfile/FindImportProfile.js
@@ -153,7 +153,7 @@ const FindImportProfile = ({
 
     try {
       const attachedProfilesWithAssociations = await Promise.all(requests);
-      const associations = attachedProfilesWithAssociations.map(item => item.childSnapshotWrappers || []);
+      const associations = attachedProfilesWithAssociations.map(item => item?.childSnapshotWrappers || []);
 
       if (profileType === ENTITY_KEYS.JOB_PROFILES && entityKey === ENTITY_KEYS.ACTION_PROFILES) {
         handleAttachingToJobProfile(associations, attachedProfilesWithAssociations, onSaveMultiple);

--- a/FindImportProfile/FindImportProfile.test.js
+++ b/FindImportProfile/FindImportProfile.test.js
@@ -78,9 +78,15 @@ jest.mock('./FindImportProfileContainer', () => ({
     </>
   ),
 }));
-jest.mock('./utils/fetchAssociations', () => {
-  return { fetchAssociations: jest.fn(() => Promise.resolve({ contentType: 'ACTION_PROFILE' })) };
-});
+jest.mock('./utils/fetchAssociations', () => ({
+  fetchAssociations: jest.fn(() => Promise.resolve({
+    id: 'testActionProfileId',
+    content: { id: 'testActionProfileId' },
+    contentType: 'ACTION_PROFILE',
+    order: 0,
+    childSnapshotWrappers: [{ contentType: 'MAPPING_PROFILE' }],
+  })),
+}));
 
 const onClose = jest.fn();
 const findImportProfileProps = {
@@ -183,7 +189,10 @@ describe('FindImportProfile', () => {
     it('should check associations', async () => {
       await act(async () => {
         fetchAssociations.mockClear();
-        fetchAssociations.mockImplementationOnce(() => Promise.resolve({ contentType: 'ACTION_PROFILE' }));
+        fetchAssociations.mockImplementationOnce(() => Promise.resolve({
+          childSnapshotWrappers: [],
+          contentType: 'ACTION_PROFILE',
+        }));
 
         renderFindImportProfile(findImportProfileProps);
         await PluginFindRecordModal.mock.calls[0][0].onSelectRow(Event, {});

--- a/FindImportProfile/utils/fetchAssociations.js
+++ b/FindImportProfile/utils/fetchAssociations.js
@@ -25,7 +25,6 @@ export const fetchAssociations = async (okapi, profileId, masterType, parentType
     createUrl(baseUrl, { [queryProfileType]: ASSOCIATION_TYPES[entityKey] }, false),
     { headers: { ...createOkapiHeaders(okapi) } },
   );
-  const body = await response.json();
 
-  return get(body, 'childSnapshotWrappers', []);
+  return await response.json() || {};
 };

--- a/FindImportProfile/utils/fetchAssociations.js
+++ b/FindImportProfile/utils/fetchAssociations.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import {
   createOkapiHeaders,
   createUrl,

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.10",
     "@babel/eslint-parser": "^7.17.0",
-    "@babel/plugin-proposal-class-properties": "^7.16.0",
     "@babel/plugin-proposal-decorators": "^7.16.4",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/plugin-transform-runtime": "^7.16.4",
     "@babel/preset-react": "^7.16.0",
     "@bigtest/interactor": "^0.9.1",

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -5,9 +5,9 @@ module.exports = {
   ],
   plugins: [
     ['@babel/plugin-proposal-decorators', { legacy: true }],
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-private-methods', { loose: true }],
-    ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
+    ['@babel/plugin-transform-class-properties', { loose: true }],
+    ['@babel/plugin-transform-private-methods', { loose: true }],
+    ['@babel/plugin-transform-private-property-in-object', { loose: true }],
     '@babel/plugin-transform-runtime',
   ],
 };


### PR DESCRIPTION
Adjust `fetchAssociations` util to return the whole response instead of just `childSnapshotWrappers`

Merge together with [UIDATIMP-1471](https://issues.folio.org/browse/UIDATIMP-1471)