### PR TITLE
UIPFIMP-65: Increase test coverage for FindImportProfile component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-plugin-find-import-profile
 
+## **7.1.0** (in progress)
+
+### Features added:
+* Jest/RTL: Increase test coverage for FindImportProfile component (UIPFIMP-65)
+
 ## [7.0.0](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v7.0.0) (2023-10-13)
 
 ### Features added:

--- a/src/FindImportProfile/FindImportProfile.test.js
+++ b/src/FindImportProfile/FindImportProfile.test.js
@@ -8,8 +8,10 @@ import { runAxeTest } from '@folio/stripes-testing';
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
 import '../../test/jest/__mock__';
-import { buildStripes } from '../../test/jest/helpers';
-import { translationsProperties } from '../../test/jest/helpers';
+import {
+  buildStripes,
+  translationsProperties,
+} from '../../test/jest/helpers';
 
 import FindImportProfile from './FindImportProfile';
 

--- a/src/FindImportProfile/FindImportProfile.test.js
+++ b/src/FindImportProfile/FindImportProfile.test.js
@@ -16,6 +16,7 @@ import FindImportProfile from './FindImportProfile';
 import { fetchAssociations } from './utils/fetchAssociations';
 import { PluginFindRecordModal } from '@folio/stripes-acq-components';
 import { ConfirmationModal } from '@folio/stripes/components';
+import { listTemplate } from '@folio/stripes-data-transfer-components';
 
 const mockModalProps = {
   closeModal: () => {},
@@ -58,6 +59,10 @@ jest.mock('@folio/stripes-acq-components', () => ({
   ),
   PluginFindRecordModal: jest.fn(() => 'PluginFindRecordModal'),
 }));
+jest.mock('@folio/stripes-data-transfer-components', () => ({
+  ...jest.requireActual('@folio/stripes-data-transfer-components'),
+  listTemplate: jest.fn(() => <span>listTemplate</span>),
+}));
 jest.mock('./FindImportProfileContainer', () => ({
   JobProfilesContainer: ({
     children,
@@ -84,7 +89,7 @@ jest.mock('./utils/fetchAssociations', () => ({
     content: { id: 'testActionProfileId' },
     contentType: 'ACTION_PROFILE',
     order: 0,
-    childSnapshotWrappers: [{ contentType: 'MAPPING_PROFILE' }],
+    childSnapshotWrappers: [{ contentType: 'ACTION_PROFILE' }],
   })),
 }));
 
@@ -126,6 +131,10 @@ const renderFindImportProfile = ({
 };
 
 describe('FindImportProfile', () => {
+  beforeEach(() => {
+    listTemplate.mockClear();
+  });
+
   it('should render with no axe errors', async () => {
     const { container } = renderFindImportProfile(findImportProfileProps);
 
@@ -146,6 +155,17 @@ describe('FindImportProfile', () => {
       });
 
       expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('when search by a term', () => {
+    it('should call a proper handler to render new records', async () => {
+      await act(async () => {
+        renderFindImportProfile(findImportProfileProps);
+        PluginFindRecordModal.mock.calls[0][0].onSearchChange('test term');
+      });
+
+      expect(listTemplate).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Links
[UIPFIMP-65](https://issues.folio.org/browse/UIPFIMP-65)

### Before
![image](https://github.com/folio-org/ui-plugin-find-import-profile/assets/85172747/39c6fded-b73c-4b94-a461-98f70574f17c)

### After
![image](https://github.com/folio-org/ui-plugin-find-import-profile/assets/85172747/00089e13-2f7e-4f1a-abf4-06774440cfd0)
