### PR TITLE
UIPFIMP-64: Jest/RTL: Cover utils with unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-plugin-find-import-profile
 
+## **7.1.0** (in progress)
+
+### Features added:
+* Jest/RTL: Cover utils with unit tests (UIPFIMP-64)
+
 ## [7.0.0](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v7.0.0) (2023-10-13)
 
 ### Features added:

--- a/src/FindImportProfile/utils/fetchAssociations.test.js
+++ b/src/FindImportProfile/utils/fetchAssociations.test.js
@@ -1,0 +1,68 @@
+import faker from 'faker';
+
+import '../../../test/jest/__mock__';
+
+import { fetchAssociations } from './fetchAssociations';
+
+global.fetch = jest.fn();
+
+const mockData = { name: 'test name' };
+const profileId = faker.random.uuid();
+const okapi = {
+  url: 'https://test.com',
+  tenant: 'tenant',
+  token: 'token',
+};
+const path = `${okapi.url}/data-import-profiles/profileAssociations/${profileId}`;
+
+describe('fetchAssociations function', () => {
+  beforeEach(() => {
+    global.fetch.mockClear();
+  });
+
+  describe('when masterType is equal to parentType', () => {
+    it('should fetch details for the entity', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockData,
+      });
+
+      const expectedUrl = `${path}/masters?detailType=JOB_PROFILE`;
+      const data = await fetchAssociations(okapi, profileId, 'ACTION_PROFILE', 'ACTION_PROFILE', 'jobProfiles');
+
+      expect(global.fetch.mock.calls[0][0]).toBe(expectedUrl);
+      expect(data).toEqual(mockData);
+    });
+  });
+
+  describe('when masterType is not equal to parentType', () => {
+    it('should fetch details for the master type', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockData,
+      });
+
+      const expectedUrl = `${path}/details?masterType=ACTION_PROFILE`;
+      const data = await fetchAssociations(okapi, profileId, 'JOB_PROFILE', 'ACTION_PROFILE', 'actionProfiles');
+
+      expect(global.fetch.mock.calls[0][0]).toBe(expectedUrl);
+      expect(data).toEqual(mockData);
+    });
+  });
+
+  describe('when there is no data', () => {
+    it('should return an empty object', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => null,
+      });
+
+      const data = await fetchAssociations(okapi, profileId, 'test', 'test', 'jobProfiles');
+
+      expect(data).toEqual({});
+    });
+  });
+});

--- a/src/FindImportProfile/utils/fetchAssociations.test.js
+++ b/src/FindImportProfile/utils/fetchAssociations.test.js
@@ -1,5 +1,3 @@
-import faker from 'faker';
-
 import '../../../test/jest/__mock__';
 
 import { fetchAssociations } from './fetchAssociations';
@@ -7,7 +5,7 @@ import { fetchAssociations } from './fetchAssociations';
 global.fetch = jest.fn();
 
 const mockData = { name: 'test name' };
-const profileId = faker.random.uuid();
+const profileId = 'testProfileId';
 const okapi = {
   url: 'https://test.com',
   tenant: 'tenant',


### PR DESCRIPTION
## Links
[UIPFIMP-64](https://issues.folio.org/browse/UIPFIMP-64)

![image](https://github.com/folio-org/ui-plugin-find-import-profile/assets/85172747/01c878fb-c94d-412a-9437-0f24d56114db)
