### PR TITLE
UIPFIMP-79: Introduce filterByRecordType prop to build query for filtered entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-plugin-find-import-profile
 
+## [9.1.0] (IN PROGRESS)
+
+### Features added:
+* Introduce filterByRecordType prop to build query for filtered entities. (UIPFIMP-79)
+
 ## [9.0.0](https://github.com/folio-org/ui-plugin-find-import-profile/tree/v9.0.0) (2025-03-13)
 
 ### Features added:

--- a/src/FindImportProfile/FindImportProfile.js
+++ b/src/FindImportProfile/FindImportProfile.js
@@ -50,6 +50,7 @@ const FindImportProfile = ({
   onClose = noop,
   isSingleSelect = false,
   isMultiLink = true,
+  filterByRecordType = '',
   ...rest
 }) => {
   const FindImportProfileContainer = profileContainers[entityKey];
@@ -197,6 +198,7 @@ const FindImportProfile = ({
           <FindImportProfileContainer
             entityKey={entityKey}
             filterParams={filterParams}
+            filterByRecordType={filterByRecordType}
           >
             {viewProps => (
               <PluginFindRecordModal
@@ -271,6 +273,7 @@ FindImportProfile.propTypes = {
   onLink: PropTypes.func.isRequired,
   onSaveMultiple: PropTypes.func,
   onClose: PropTypes.func,
+  filterByRecordType: PropTypes.string,
 };
 
 export default FindImportProfile;

--- a/src/FindImportProfile/FindImportProfileContainer/AbstractContainer.js
+++ b/src/FindImportProfile/FindImportProfileContainer/AbstractContainer.js
@@ -21,7 +21,10 @@ export class AbstractContainer extends Component {
 
   componentDidMount() {
     this.source = new StripesConnectedSource(this.props, this.logger);
-    this.props.mutator.query.update({ sort: 'name' });
+    this.props.mutator.query.update({
+      sort: 'name',
+      filterByRecordType: this.props.filterByRecordType,
+    });
   }
 
   componentDidUpdate() {
@@ -97,4 +100,5 @@ AbstractContainer.propTypes = {
     PropTypes.node,
   ]).isRequired,
   entityKey: PropTypes.string,
+  filterByRecordType: PropTypes.string,
 };


### PR DESCRIPTION
Required by https://github.com/folio-org/ui-data-import/pull/1698

### Purpose
Introduce `filterByRecordType` prop to Plugin and update query with this filter in `AbstractContainer` component to filter data import profiles by record type

### Refs
https://folio-org.atlassian.net/browse/UIPFIMP-79